### PR TITLE
Feat: 스터디그룹 공지사항 API 구현

### DIFF
--- a/src/main/java/com/springcooler/sgma/studygroupnotice/command/application/controller/StudyGroupNoticeController.java
+++ b/src/main/java/com/springcooler/sgma/studygroupnotice/command/application/controller/StudyGroupNoticeController.java
@@ -33,4 +33,11 @@ public class StudyGroupNoticeController {
     public ResponseEntity<?> modifyStudyGroupNotice(@RequestBody StudyGroupNoticeDTO modifyNotice) {
         return ResponseEntity.ok(studyGroupNoticeService.modifyStudyGroupNotice(modifyNotice));
     }
+
+    // 스터디그룹 공지사항 삭제
+    @DeleteMapping("/{noticeId}")
+    public ResponseEntity<?> deleteStudyGroupNotice(@PathVariable long noticeId) {
+        studyGroupNoticeService.deleteStudyGroupNotice(noticeId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/springcooler/sgma/studygroupnotice/command/application/controller/StudyGroupNoticeController.java
+++ b/src/main/java/com/springcooler/sgma/studygroupnotice/command/application/controller/StudyGroupNoticeController.java
@@ -1,9 +1,34 @@
 package com.springcooler.sgma.studygroupnotice.command.application.controller;
 
+import com.springcooler.sgma.studygroupnotice.command.application.dto.StudyGroupNoticeDTO;
+import com.springcooler.sgma.studygroupnotice.command.application.service.AppStudyGroupNoticeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
 
 @RestController("commandStudyGroupNoticeController")
 @RequestMapping("/api/study-group/notices")
 public class StudyGroupNoticeController {
+
+    private final AppStudyGroupNoticeService studyGroupNoticeService;
+
+    @Autowired
+    public StudyGroupNoticeController(AppStudyGroupNoticeService studyGroupNoticeService) {
+        this.studyGroupNoticeService = studyGroupNoticeService;
+    }
+
+    // 스터디그룹 공지사항 생성
+    @PostMapping("/")
+    public ResponseEntity<?>  registStudyGroupNotice(@RequestBody StudyGroupNoticeDTO newNotice) {
+        return ResponseEntity
+                .created(URI.create("/api/study-group/notices/"
+                        + studyGroupNoticeService.registStudyGroupNotice(newNotice).getNoticeId()))
+                .build();
+    }
+
 }

--- a/src/main/java/com/springcooler/sgma/studygroupnotice/command/application/controller/StudyGroupNoticeController.java
+++ b/src/main/java/com/springcooler/sgma/studygroupnotice/command/application/controller/StudyGroupNoticeController.java
@@ -4,10 +4,7 @@ import com.springcooler.sgma.studygroupnotice.command.application.dto.StudyGroup
 import com.springcooler.sgma.studygroupnotice.command.application.service.AppStudyGroupNoticeService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -24,11 +21,16 @@ public class StudyGroupNoticeController {
 
     // 스터디그룹 공지사항 생성
     @PostMapping("/")
-    public ResponseEntity<?>  registStudyGroupNotice(@RequestBody StudyGroupNoticeDTO newNotice) {
+    public ResponseEntity<?> registStudyGroupNotice(@RequestBody StudyGroupNoticeDTO newNotice) {
         return ResponseEntity
                 .created(URI.create("/api/study-group/notices/"
                         + studyGroupNoticeService.registStudyGroupNotice(newNotice).getNoticeId()))
                 .build();
     }
 
+    // 스터디그룹 공지사항 정보 수정
+    @PutMapping("/")
+    public ResponseEntity<?> modifyStudyGroupNotice(@RequestBody StudyGroupNoticeDTO modifyNotice) {
+        return ResponseEntity.ok(studyGroupNoticeService.modifyStudyGroupNotice(modifyNotice));
+    }
 }

--- a/src/main/java/com/springcooler/sgma/studygroupnotice/command/application/service/AppStudyGroupNoticeService.java
+++ b/src/main/java/com/springcooler/sgma/studygroupnotice/command/application/service/AppStudyGroupNoticeService.java
@@ -5,10 +5,10 @@ import com.springcooler.sgma.studygroupnotice.command.domain.aggregate.StudyGrou
 
 public interface AppStudyGroupNoticeService {
 
-    StudyGroupNotice registStudyGroupNotice(StudyGroupNoticeDTO studyGroupNotice);
+    StudyGroupNotice registStudyGroupNotice(StudyGroupNoticeDTO newNotice);
 
-    StudyGroupNotice modifyStudyGroupNotice(StudyGroupNoticeDTO studyGroupNotice);
+    StudyGroupNotice modifyStudyGroupNotice(StudyGroupNoticeDTO modifyNotice);
 
-    void deleteStudyGroupNotice(StudyGroupNoticeDTO studyGroupNotice);
+    void deleteStudyGroupNotice(long noticeId);
 
 }

--- a/src/main/java/com/springcooler/sgma/studygroupnotice/command/application/service/AppStudyGroupNoticeService.java
+++ b/src/main/java/com/springcooler/sgma/studygroupnotice/command/application/service/AppStudyGroupNoticeService.java
@@ -1,4 +1,14 @@
 package com.springcooler.sgma.studygroupnotice.command.application.service;
 
+import com.springcooler.sgma.studygroupnotice.command.application.dto.StudyGroupNoticeDTO;
+import com.springcooler.sgma.studygroupnotice.command.domain.aggregate.StudyGroupNotice;
+
 public interface AppStudyGroupNoticeService {
+
+    StudyGroupNotice registStudyGroupNotice(StudyGroupNoticeDTO studyGroupNotice);
+
+    StudyGroupNotice modifyStudyGroupNotice(StudyGroupNoticeDTO studyGroupNotice);
+
+    void deleteStudyGroupNotice(StudyGroupNoticeDTO studyGroupNotice);
+
 }

--- a/src/main/java/com/springcooler/sgma/studygroupnotice/command/application/service/AppStudyGroupNoticeServiceImpl.java
+++ b/src/main/java/com/springcooler/sgma/studygroupnotice/command/application/service/AppStudyGroupNoticeServiceImpl.java
@@ -4,6 +4,7 @@ import com.springcooler.sgma.studygroupnotice.command.application.dto.StudyGroup
 import com.springcooler.sgma.studygroupnotice.command.domain.aggregate.StudyGroupNotice;
 import com.springcooler.sgma.studygroupnotice.command.domain.aggregate.StudyGroupNoticeStatus;
 import com.springcooler.sgma.studygroupnotice.command.domain.repository.StudyGroupNoticeRepository;
+import jakarta.persistence.EntityNotFoundException;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -35,10 +36,22 @@ public class AppStudyGroupNoticeServiceImpl implements AppStudyGroupNoticeServic
         return studyGroupNoticeRepository.save(modelMapper.map(newNotice, StudyGroupNotice.class));
     }
 
+
+    // 스터디그룹 공지사항 정보 수정
     @Transactional
     @Override
-    public StudyGroupNotice modifyStudyGroupNotice(StudyGroupNoticeDTO studyGroupNotice) {
-        return null;
+    public StudyGroupNotice modifyStudyGroupNotice(StudyGroupNoticeDTO modifyNotice) {
+        // 기존 엔티티 조회
+        StudyGroupNotice existingNotice =
+                studyGroupNoticeRepository.findById(modifyNotice.getNoticeId())
+                        .orElseThrow(() -> new EntityNotFoundException("잘못된 수정 요청입니다."));
+
+        // 바뀐 제목, 내용, 수정 시각 업데이트
+        existingNotice.setTitle(modifyNotice.getTitle());
+        existingNotice.setContent(modifyNotice.getContent());
+        existingNotice.setUpdatedAt(new Timestamp(System.currentTimeMillis()));
+
+        return studyGroupNoticeRepository.save(existingNotice);
     }
 
     @Transactional

--- a/src/main/java/com/springcooler/sgma/studygroupnotice/command/application/service/AppStudyGroupNoticeServiceImpl.java
+++ b/src/main/java/com/springcooler/sgma/studygroupnotice/command/application/service/AppStudyGroupNoticeServiceImpl.java
@@ -1,10 +1,10 @@
 package com.springcooler.sgma.studygroupnotice.command.application.service;
 
-import com.springcooler.sgma.studygroup.command.domain.service.DomainStudyGroupService;
 import com.springcooler.sgma.studygroupnotice.command.application.dto.StudyGroupNoticeDTO;
 import com.springcooler.sgma.studygroupnotice.command.domain.aggregate.StudyGroupNotice;
 import com.springcooler.sgma.studygroupnotice.command.domain.aggregate.StudyGroupNoticeStatus;
 import com.springcooler.sgma.studygroupnotice.command.domain.repository.StudyGroupNoticeRepository;
+import com.springcooler.sgma.studygroupnotice.command.domain.service.DomainStudyGroupNoticeService;
 import jakarta.persistence.EntityNotFoundException;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,15 +17,15 @@ import java.sql.Timestamp;
 public class AppStudyGroupNoticeServiceImpl implements AppStudyGroupNoticeService {
 
     private final ModelMapper modelMapper;
-    private final DomainStudyGroupService domainStudyGroupService;
+    private final DomainStudyGroupNoticeService domainStudyGroupNoticeService;
     private final StudyGroupNoticeRepository studyGroupNoticeRepository;
 
     @Autowired
     public AppStudyGroupNoticeServiceImpl(ModelMapper modelMapper,
-                                          DomainStudyGroupService domainStudyGroupService,
+                                          DomainStudyGroupNoticeService domainStudyGroupNoticeService,
                                           StudyGroupNoticeRepository studyGroupNoticeRepository) {
         this.modelMapper = modelMapper;
-        this.domainStudyGroupService = domainStudyGroupService;
+        this.domainStudyGroupNoticeService = domainStudyGroupNoticeService;
         this.studyGroupNoticeRepository = studyGroupNoticeRepository;
     }
 
@@ -67,7 +67,7 @@ public class AppStudyGroupNoticeServiceImpl implements AppStudyGroupNoticeServic
                         .orElseThrow(() -> new EntityNotFoundException("잘못된 삭제 요청입니다."));
 
         // 유효성 검사
-        if(!domainStudyGroupService.isActive(deleteNotice.getActiveStatus()))
+        if(!domainStudyGroupNoticeService.isActive(deleteNotice.getActiveStatus()))
             throw new EntityNotFoundException("잘못된 삭제 요청입니다.");
 
         // INACTIVE 처리

--- a/src/main/java/com/springcooler/sgma/studygroupnotice/command/application/service/AppStudyGroupNoticeServiceImpl.java
+++ b/src/main/java/com/springcooler/sgma/studygroupnotice/command/application/service/AppStudyGroupNoticeServiceImpl.java
@@ -1,7 +1,49 @@
 package com.springcooler.sgma.studygroupnotice.command.application.service;
 
+import com.springcooler.sgma.studygroupnotice.command.application.dto.StudyGroupNoticeDTO;
+import com.springcooler.sgma.studygroupnotice.command.domain.aggregate.StudyGroupNotice;
+import com.springcooler.sgma.studygroupnotice.command.domain.aggregate.StudyGroupNoticeStatus;
+import com.springcooler.sgma.studygroupnotice.command.domain.repository.StudyGroupNoticeRepository;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
 
 @Service
 public class AppStudyGroupNoticeServiceImpl implements AppStudyGroupNoticeService {
+
+    private final ModelMapper modelMapper;
+    private final StudyGroupNoticeRepository studyGroupNoticeRepository;
+
+    @Autowired
+    public AppStudyGroupNoticeServiceImpl(ModelMapper modelMapper,
+                                          StudyGroupNoticeRepository studyGroupNoticeRepository) {
+        this.modelMapper = modelMapper;
+        this.studyGroupNoticeRepository = studyGroupNoticeRepository;
+    }
+
+    // 스터디그룹 공지사항 생성
+    @Transactional
+    @Override
+    public StudyGroupNotice registStudyGroupNotice(StudyGroupNoticeDTO newNotice) {
+        // 생성 시각, 활성화 여부 초기화
+        newNotice.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+        newNotice.setActiveStatus(StudyGroupNoticeStatus.ACTIVE.name());
+
+        return studyGroupNoticeRepository.save(modelMapper.map(newNotice, StudyGroupNotice.class));
+    }
+
+    @Transactional
+    @Override
+    public StudyGroupNotice modifyStudyGroupNotice(StudyGroupNoticeDTO studyGroupNotice) {
+        return null;
+    }
+
+    @Transactional
+    @Override
+    public void deleteStudyGroupNotice(StudyGroupNoticeDTO studyGroupNotice) {
+
+    }
 }

--- a/src/main/java/com/springcooler/sgma/studygroupnotice/command/domain/service/DomainStudyGroupNoticeService.java
+++ b/src/main/java/com/springcooler/sgma/studygroupnotice/command/domain/service/DomainStudyGroupNoticeService.java
@@ -1,4 +1,7 @@
 package com.springcooler.sgma.studygroupnotice.command.domain.service;
 
 public interface DomainStudyGroupNoticeService {
+
+    boolean isActive(String activeStatus);
+
 }

--- a/src/main/java/com/springcooler/sgma/studygroupnotice/command/domain/service/DomainStudyGroupNoticeServiceImpl.java
+++ b/src/main/java/com/springcooler/sgma/studygroupnotice/command/domain/service/DomainStudyGroupNoticeServiceImpl.java
@@ -1,7 +1,14 @@
 package com.springcooler.sgma.studygroupnotice.command.domain.service;
 
+import com.springcooler.sgma.studygroupnotice.command.domain.aggregate.StudyGroupNoticeStatus;
 import org.springframework.stereotype.Service;
 
 @Service
 public class DomainStudyGroupNoticeServiceImpl implements DomainStudyGroupNoticeService {
+
+    @Override
+    public boolean isActive(String activeStatus) {
+        return activeStatus.equals(StudyGroupNoticeStatus.ACTIVE.name());
+    }
+
 }

--- a/src/test/java/com/springcooler/sgma/studygroupnotice/command/application/service/StudyGroupNoticeServiceTests.java
+++ b/src/test/java/com/springcooler/sgma/studygroupnotice/command/application/service/StudyGroupNoticeServiceTests.java
@@ -1,4 +1,37 @@
 package com.springcooler.sgma.studygroupnotice.command.application.service;
 
+import com.springcooler.sgma.studygroupnotice.command.application.dto.StudyGroupNoticeDTO;
+import com.springcooler.sgma.studygroupnotice.command.domain.aggregate.StudyGroupNotice;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
 class StudyGroupNoticeServiceTests {
+
+    @Autowired
+    private AppStudyGroupNoticeService studyGroupNoticeService;
+
+    @DisplayName("스터디그룹 공지사항 생성 테스트")
+    @Test
+    void testRegistStudyGroupNotice() {
+        //Given
+        StudyGroupNoticeDTO newNotice = new StudyGroupNoticeDTO();
+        newNotice.setTitle("테스트용 제목");
+        newNotice.setContent("테스트용 내용");
+        newNotice.setGroupId(1L);
+
+        //When
+        StudyGroupNotice notice = studyGroupNoticeService.registStudyGroupNotice(newNotice);
+        if (notice != null) {
+            System.out.println(notice);
+        }
+
+        //Then
+        Assertions.assertNotNull(notice);
+    }
 }

--- a/src/test/java/com/springcooler/sgma/studygroupnotice/command/application/service/StudyGroupNoticeServiceTests.java
+++ b/src/test/java/com/springcooler/sgma/studygroupnotice/command/application/service/StudyGroupNoticeServiceTests.java
@@ -34,4 +34,23 @@ class StudyGroupNoticeServiceTests {
         //Then
         Assertions.assertNotNull(notice);
     }
+
+    @DisplayName("스터디그룹 공지사항 정보 수정 테스트")
+    @Test
+    void testModifyStudyGroupNotice() {
+        //Given
+        StudyGroupNoticeDTO modifyNotice = new StudyGroupNoticeDTO();
+        modifyNotice.setNoticeId(1L);
+        modifyNotice.setTitle("바뀐 제목");
+        modifyNotice.setContent("바뀐 내용");
+
+        //When
+        StudyGroupNotice notice = studyGroupNoticeService.modifyStudyGroupNotice(modifyNotice);
+        if (notice != null) {
+            System.out.println(notice);
+        }
+
+        //Then
+        Assertions.assertNotNull(notice);
+    }
 }

--- a/src/test/java/com/springcooler/sgma/studygroupnotice/command/application/service/StudyGroupNoticeServiceTests.java
+++ b/src/test/java/com/springcooler/sgma/studygroupnotice/command/application/service/StudyGroupNoticeServiceTests.java
@@ -2,6 +2,7 @@ package com.springcooler.sgma.studygroupnotice.command.application.service;
 
 import com.springcooler.sgma.studygroupnotice.command.application.dto.StudyGroupNoticeDTO;
 import com.springcooler.sgma.studygroupnotice.command.domain.aggregate.StudyGroupNotice;
+import com.springcooler.sgma.studygroupnotice.command.domain.repository.StudyGroupNoticeRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +16,9 @@ class StudyGroupNoticeServiceTests {
 
     @Autowired
     private AppStudyGroupNoticeService studyGroupNoticeService;
+
+    @Autowired
+    private StudyGroupNoticeRepository studyGroupNoticeRepository;
 
     @DisplayName("스터디그룹 공지사항 생성 테스트")
     @Test
@@ -52,5 +56,20 @@ class StudyGroupNoticeServiceTests {
 
         //Then
         Assertions.assertNotNull(notice);
+    }
+
+    @DisplayName("스터디그룹 공지사항 삭제 테스트")
+    @Test
+    void testDeleteStudyGroupNotice() {
+        //Given
+        long noticeId = 1L;
+
+        //When
+        studyGroupNoticeService.deleteStudyGroupNotice(noticeId);
+        System.out.println("DELETE SUCCESS");
+
+        //Then
+        String activeStatus = studyGroupNoticeRepository.findById(noticeId).orElseThrow().getActiveStatus();
+        Assertions.assertEquals("INACTIVE", activeStatus);
     }
 }


### PR DESCRIPTION
---
name: 스터디그룹 공지사항 API 구현
about: CUD
title: 스터디그룹 공지사항 API 구현
labels: enhancement
assignees: @Chochanguk 

---

## 코드 변경 사유
- [x] 신규 기능 추가
- [ ] 기존 기능 수정
- [ ] 버그 수정

## 관련 이슈 (버그 수정인 경우)
- 
- 

## 테스트 계획 및 진행 상황
- [x] 제목,내용,그룹 아이디 만으로 스터디그룹 공지사항이 등록되도록 구현

소스코드
```Java
    // 스터디그룹 공지사항 생성
    @Transactional
    @Override
    public StudyGroupNotice registStudyGroupNotice(StudyGroupNoticeDTO newNotice) {
        // 생성 시각, 활성화 여부 초기화
        newNotice.setCreatedAt(new Timestamp(System.currentTimeMillis()));
        newNotice.setActiveStatus(StudyGroupNoticeStatus.ACTIVE.name());

        return studyGroupNoticeRepository.save(modelMapper.map(newNotice, StudyGroupNotice.class));
    }
```

테스트코드
```Java
    @DisplayName("스터디그룹 공지사항 생성 테스트")
    @Test
    void testRegistStudyGroupNotice() {
        //Given
        StudyGroupNoticeDTO newNotice = new StudyGroupNoticeDTO();
        newNotice.setTitle("테스트용 제목");
        newNotice.setContent("테스트용 내용");
        newNotice.setGroupId(1L);

        //When
        StudyGroupNotice notice = studyGroupNoticeService.registStudyGroupNotice(newNotice);
        if (notice != null) {
            System.out.println(notice);
        }

        //Then
        Assertions.assertNotNull(notice);
    }
```

테스트결과

![image](https://github.com/user-attachments/assets/7f5ff05f-d950-4450-b988-c251baf81fe7)

---

- [x] 공지사항 아이디, 제목, 내용 만으로 스터디그룹 공지사항을 수정할 수 있도록 구현

소스코드
```Java
    // 스터디그룹 공지사항 정보 수정
    @Transactional
    @Override
    public StudyGroupNotice modifyStudyGroupNotice(StudyGroupNoticeDTO modifyNotice) {
        // 기존 엔티티 조회
        StudyGroupNotice existingNotice =
                studyGroupNoticeRepository.findById(modifyNotice.getNoticeId())
                        .orElseThrow(() -> new EntityNotFoundException("잘못된 수정 요청입니다."));

        // 바뀐 제목, 내용, 수정 시각 업데이트
        existingNotice.setTitle(modifyNotice.getTitle());
        existingNotice.setContent(modifyNotice.getContent());
        existingNotice.setUpdatedAt(new Timestamp(System.currentTimeMillis()));

        return studyGroupNoticeRepository.save(existingNotice);
    }
```

테스트코드
```Java
    @DisplayName("스터디그룹 공지사항 정보 수정 테스트")
    @Test
    void testModifyStudyGroupNotice() {
        //Given
        StudyGroupNoticeDTO modifyNotice = new StudyGroupNoticeDTO();
        modifyNotice.setNoticeId(1L);
        modifyNotice.setTitle("바뀐 제목");
        modifyNotice.setContent("바뀐 내용");

        //When
        StudyGroupNotice notice = studyGroupNoticeService.modifyStudyGroupNotice(modifyNotice);
        if (notice != null) {
            System.out.println(notice);
        }

        //Then
        Assertions.assertNotNull(notice);
    }
```

테스트결과

![image](https://github.com/user-attachments/assets/3294dbc3-2a4c-4383-aa12-3d6d376ed245)

---

- [x] 공지사항 아이디로 스터디그룹 공지사항을 삭제할 수 있도록 구현

소스코드
```Java
    // 스터디그룹 공지사항 삭제
    @Transactional
    @Override
    public void deleteStudyGroupNotice(long noticeId) {
        // 기존 엔티티 조회
        StudyGroupNotice deleteNotice =
                studyGroupNoticeRepository.findById(noticeId)
                        .orElseThrow(() -> new EntityNotFoundException("잘못된 삭제 요청입니다."));

        // 유효성 검사
        if(!domainStudyGroupNoticeService.isActive(deleteNotice.getActiveStatus()))
            throw new EntityNotFoundException("잘못된 삭제 요청입니다.");

        // INACTIVE 처리
        deleteNotice.setActiveStatus(StudyGroupNoticeStatus.INACTIVE.name());
        studyGroupNoticeRepository.save(deleteNotice);
    }
```

테스트코드
```Java
    @DisplayName("스터디그룹 공지사항 삭제 테스트")
    @Test
    void testDeleteStudyGroupNotice() {
        //Given
        long noticeId = 1L;

        //When
        studyGroupNoticeService.deleteStudyGroupNotice(noticeId);
        System.out.println("DELETE SUCCESS");

        //Then
        String activeStatus = studyGroupNoticeRepository.findById(noticeId).orElseThrow().getActiveStatus();
        Assertions.assertEquals("INACTIVE", activeStatus);
    }
```

테스트결과

![image](https://github.com/user-attachments/assets/0762a44e-2b8a-4aef-847b-64673f36a3d2)

## 기타 참고 사항
- #44, #45, #46
