### PR TITLE
Feat: 스터디그룹원 회원별 조회 API 추가

### DIFF
--- a/src/main/java/com/springcooler/sgma/studygroupmember/query/controller/StudyGroupMemberController.java
+++ b/src/main/java/com/springcooler/sgma/studygroupmember/query/controller/StudyGroupMemberController.java
@@ -47,6 +47,16 @@ public class StudyGroupMemberController {
         return getResponseEntity(headers, studyGroupMemberService.findStudyGroupMembersByGroupId(groupId));
     }
 
+    // 스터디 그룹원 회원별 조회
+    @GetMapping("/user-id/{userId}")
+    public ResponseEntity<ResponseMessage> findStudyGroupMembersByUserId(@PathVariable long userId) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "json"
+                , StandardCharsets.UTF_8));
+
+        return getResponseEntity(headers, studyGroupMemberService.findStudyGroupMembersByUserId(userId));
+    }
+
     private ResponseEntity<ResponseMessage> getResponseEntity(HttpHeaders headers, List<StudyGroupMemberDTO> members) {
         ResponseMessage responseMessage;
 

--- a/src/main/java/com/springcooler/sgma/studygroupmember/query/repository/StudyGroupMemberMapper.java
+++ b/src/main/java/com/springcooler/sgma/studygroupmember/query/repository/StudyGroupMemberMapper.java
@@ -14,4 +14,7 @@ public interface StudyGroupMemberMapper {
     // 스터디 그룹원 그룹별 조회
     List<StudyGroupMemberDTO> findStudyGroupMembersByGroupId(long groupId);
 
+    // 스터디 그룹원 회원별 조회
+    List<StudyGroupMemberDTO> findStudyGroupMembersByUserId(long userId);
+
 }

--- a/src/main/java/com/springcooler/sgma/studygroupmember/query/service/StudyGroupMemberService.java
+++ b/src/main/java/com/springcooler/sgma/studygroupmember/query/service/StudyGroupMemberService.java
@@ -12,4 +12,7 @@ public interface StudyGroupMemberService {
     // 스터디 그룹원 그룹별 조회
     List<StudyGroupMemberDTO> findStudyGroupMembersByGroupId(long groupId);
 
+    // 스터디 그룹원 회원별 조회
+    List<StudyGroupMemberDTO> findStudyGroupMembersByUserId(long userId);
+
 }

--- a/src/main/java/com/springcooler/sgma/studygroupmember/query/service/StudyGroupMemberServiceImpl.java
+++ b/src/main/java/com/springcooler/sgma/studygroupmember/query/service/StudyGroupMemberServiceImpl.java
@@ -29,4 +29,9 @@ public class StudyGroupMemberServiceImpl implements StudyGroupMemberService {
         return studyGroupMemberMapper.findStudyGroupMembersByGroupId(groupId);
     }
 
+    @Override
+    public List<StudyGroupMemberDTO> findStudyGroupMembersByUserId(long userId) {
+        return studyGroupMemberMapper.findStudyGroupMembersByUserId(userId);
+    }
+
 }

--- a/src/main/resources/com/springcooler/sgma/studygroupmember/query/repository/StudyGroupMemberMapper.xml
+++ b/src/main/resources/com/springcooler/sgma/studygroupmember/query/repository/StudyGroupMemberMapper.xml
@@ -38,4 +38,17 @@
          ORDER BY A.MEMBER_ID
     </select>
 
+    <select id="findStudyGroupMembersByUserId" resultMap="studyGroupMemberResultMap" parameterType="long">
+        SELECT
+               A.MEMBER_ID
+             , A.MEMBER_ENROLLED_AT
+             , A.MEMBER_WITHDRAWN_AT
+             , A.MEMBER_STATUS
+             , A.USER_ID
+             , A.GROUP_ID
+          FROM STUDY_GROUP_MEMBER A
+         WHERE A.MEMBER_STATUS = 'ACTIVE' AND A.USER_ID = #{ userId }
+         ORDER BY A.MEMBER_ID
+    </select>
+
 </mapper>

--- a/src/test/java/com/springcooler/sgma/studygroupmember/query/service/StudyGroupMemberServiceTests.java
+++ b/src/test/java/com/springcooler/sgma/studygroupmember/query/service/StudyGroupMemberServiceTests.java
@@ -42,4 +42,17 @@ class StudyGroupMemberServiceTests {
         );
     }
 
+    @DisplayName("스터디 그룹원 회원별 조회 테스트")
+    @ParameterizedTest
+    @ValueSource(longs = 1)
+    void testFindStudyGroupMembersByUserId(long userId) {
+        Assertions.assertDoesNotThrow(
+                () -> {
+                    List<StudyGroupMemberDTO> studyGroupMembers
+                            = studyGroupMemberService.findStudyGroupMembersByUserId(userId);
+                    studyGroupMembers.forEach(System.out::println);
+                }
+        );
+    }
+
 }


### PR DESCRIPTION
---
name: 스터디그룹원 회원별 조회 API 추가
about: userId로 해당되는 유저의 모든 스터디그룹원 정보 조회 
title: 스터디그룹원 회원별 조회 API 추가
labels: enhancement

---

## 코드 변경 사유
- [x] 신규 기능 추가
- [ ] 기존 기능 수정
- [ ] 버그 수정

## 테스트 계획 및 진행 상황
- [x] 회원아이디로 스터디그룹원 조회할 수 있도록 구현

소스코드
```Sql
        SELECT
               A.MEMBER_ID
             , A.MEMBER_ENROLLED_AT
             , A.MEMBER_WITHDRAWN_AT
             , A.MEMBER_STATUS
             , A.USER_ID
             , A.GROUP_ID
          FROM STUDY_GROUP_MEMBER A
         WHERE A.MEMBER_STATUS = 'ACTIVE' AND A.USER_ID = #{ userId }
         ORDER BY A.MEMBER_ID
```

테스트코드
```Java
    @DisplayName("스터디 그룹원 회원별 조회 테스트")
    @ParameterizedTest
    @ValueSource(longs = 1)
    void testFindStudyGroupMembersByUserId(long userId) {
        Assertions.assertDoesNotThrow(
                () -> {
                    List<StudyGroupMemberDTO> studyGroupMembers
                            = studyGroupMemberService.findStudyGroupMembersByUserId(userId);
                    studyGroupMembers.forEach(System.out::println);
                }
        );
    }
```

테스트결과

![image](https://github.com/user-attachments/assets/3a4ebb52-2f33-428c-a090-9d9266e551e9)

## 기타 참고 사항
close #95 
