### PR TITLE
Refactor: user 도메인 json형식 수정 및 시간 타입 변경

### DIFF
--- a/src/main/java/com/springcooler/sgma/user/command/application/controller/UserController.java
+++ b/src/main/java/com/springcooler/sgma/user/command/application/controller/UserController.java
@@ -1,7 +1,7 @@
 package com.springcooler.sgma.user.command.application.controller;
 
-import com.springcooler.sgma.user.command.application.vo.ResponseUserVO;
-import com.springcooler.sgma.user.command.application.vo.RequestUpdateUserVO;
+import com.springcooler.sgma.user.command.domain.aggregate.vo.ResponseUserVO;
+import com.springcooler.sgma.user.command.domain.aggregate.vo.RequestUpdateUserVO;
 import com.springcooler.sgma.user.common.ResponseDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;

--- a/src/main/java/com/springcooler/sgma/user/command/application/service/UserService.java
+++ b/src/main/java/com/springcooler/sgma/user/command/application/service/UserService.java
@@ -1,6 +1,6 @@
 package com.springcooler.sgma.user.command.application.service;
 
-import com.springcooler.sgma.user.command.application.vo.RequestUpdateUserVO;
+import com.springcooler.sgma.user.command.domain.aggregate.vo.RequestUpdateUserVO;
 import com.springcooler.sgma.user.command.domain.aggregate.UserEntity;
 
 public interface UserService{

--- a/src/main/java/com/springcooler/sgma/user/command/application/service/UserServiceImpl.java
+++ b/src/main/java/com/springcooler/sgma/user/command/application/service/UserServiceImpl.java
@@ -1,6 +1,6 @@
 package com.springcooler.sgma.user.command.application.service;
 
-import com.springcooler.sgma.user.command.application.vo.RequestUpdateUserVO;
+import com.springcooler.sgma.user.command.domain.aggregate.vo.RequestUpdateUserVO;
 import com.springcooler.sgma.user.command.domain.aggregate.UserEntity;
 import com.springcooler.sgma.user.command.domain.repository.UserRepository;
 import com.springcooler.sgma.user.common.exception.CommonException;

--- a/src/main/java/com/springcooler/sgma/user/command/domain/aggregate/UserEntity.java
+++ b/src/main/java/com/springcooler/sgma/user/command/domain/aggregate/UserEntity.java
@@ -3,7 +3,7 @@ package com.springcooler.sgma.user.command.domain.aggregate;
 import jakarta.persistence.*;
 import lombok.Data;
 
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "USER")
@@ -27,36 +27,40 @@ public class UserEntity {
     @Column(name = "email", nullable = false, length = 255)
     private String email;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "user_status", nullable = false, length = 255)
-    private String userStatus = "ACTIVE";
+    private ActiveStatus userStatus =  ActiveStatus.ACTIVE; //필기. Enum타입으로 정의
 
     @Column(name = "created_at")
-    private Timestamp createdAt;
+    private LocalDateTime createdAt;
 
     @Column(name = "withdrawn_at")
-    private Timestamp withdrawnAt;
+    private LocalDateTime withdrawnAt;
 
     @Column(name = "profile_image", columnDefinition = "TEXT")
     private String profileImage;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "accept_status", nullable = false, length = 255)
-    private String acceptStatus = "N";
+    private AcceptStatus acceptStatus = AcceptStatus.N;  //필기. Enum타입으로 정의
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "signup_path", length = 255)
-    private String signupPath;
+    private SignupPath signupPath; //필기. Enum타입으로 정의
 
-    //필기. 사용자 정보 비활성화로 설정
+    // 사용자 정보 비활성화로 설정
     public void deactivateUser() {
-        this.userStatus = "INACTIVE";
-        this.withdrawnAt = new Timestamp(System.currentTimeMillis());
+        this.userStatus = ActiveStatus.INACTIVE;
+        this.withdrawnAt = LocalDateTime.now().withNano(0); // 필기. 초 단위까지만 설정
     }
 
-    //필기. 사용자 정보 활성화로 설정
+    // 사용자 정보 활성화로 설정
     public void activateUser() {
-        this.userStatus = "ACTIVE";
+        this.userStatus = ActiveStatus.ACTIVE;
+        this.withdrawnAt = null; // 재활성화 시 탈퇴 시간을 초기화
     }
-    
-    //필기. 사용자 정보 변경(닉네임, 사진)
+
+    // 사용자 정보 변경(닉네임, 사진)
     public void updateProfile(String nickname, String profileImage) {
         if (nickname != null && !nickname.isEmpty()) {
             this.nickname = nickname;

--- a/src/main/java/com/springcooler/sgma/user/command/domain/aggregate/vo/RequestUpdateUserVO.java
+++ b/src/main/java/com/springcooler/sgma/user/command/domain/aggregate/vo/RequestUpdateUserVO.java
@@ -1,4 +1,4 @@
-package com.springcooler.sgma.user.command.application.vo;
+package com.springcooler.sgma.user.command.domain.aggregate.vo;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;

--- a/src/main/java/com/springcooler/sgma/user/command/domain/aggregate/vo/ResponseUserVO.java
+++ b/src/main/java/com/springcooler/sgma/user/command/domain/aggregate/vo/ResponseUserVO.java
@@ -1,7 +1,12 @@
-package com.springcooler.sgma.user.command.application.vo;
+package com.springcooler.sgma.user.command.domain.aggregate.vo;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.springcooler.sgma.user.command.domain.aggregate.AcceptStatus;
+import com.springcooler.sgma.user.command.domain.aggregate.ActiveStatus;
+import com.springcooler.sgma.user.command.domain.aggregate.SignupPath;
 import lombok.Data;
+
+import java.time.LocalDateTime;
 
 @Data
 public class ResponseUserVO {
@@ -22,20 +27,20 @@ public class ResponseUserVO {
     private String email;
 
     @JsonProperty("user_status")
-    private String userStatus;
+    private ActiveStatus userStatus;  // Enum 타입으로 정의
 
     @JsonProperty("created_at")
-    private String createdAt;
+    private LocalDateTime createdAt;
 
     @JsonProperty("withdrawn_at")
-    private String withdrawnAt;
+    private LocalDateTime withdrawnAt;
 
     @JsonProperty("profile_image")
     private String profileImage;
 
     @JsonProperty("accept_status")
-    private String acceptStatus;
+    private AcceptStatus acceptStatus;  // Enum 타입으로 정의
 
     @JsonProperty("signup_path")
-    private String signupPath;
+    private SignupPath signupPath;  // Enum 타입으로 정의
 }

--- a/src/main/java/com/springcooler/sgma/user/query/controller/UserController.java
+++ b/src/main/java/com/springcooler/sgma/user/query/controller/UserController.java
@@ -37,7 +37,7 @@ public class UserController {
     // 사용자 ID로 조회
     @GetMapping("/user-id/{userId}")
     public ResponseDTO<?> getUserById(@PathVariable Long userId) {
-        UserDTO userDTO = userService.getUserByuUserId(userId);
+        UserDTO userDTO = userService.getUserByUserId(userId);
         return ResponseDTO.ok(userDTO);
     }
 

--- a/src/main/java/com/springcooler/sgma/user/query/dto/RecruitmentBoardCommentDTO.java
+++ b/src/main/java/com/springcooler/sgma/user/query/dto/RecruitmentBoardCommentDTO.java
@@ -1,5 +1,6 @@
 package com.springcooler.sgma.user.query.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -7,12 +8,27 @@ import java.util.List;
 
 @Data
 public class RecruitmentBoardCommentDTO {
+    @JsonProperty("comment_id")
     private Long commentId;
+
+    @JsonProperty("content")
     private String content;
+
+    @JsonProperty("created_at")
     private LocalDateTime createdAt;
+
+    @JsonProperty("updated_at")
     private LocalDateTime updatedAt;
+
+    @JsonProperty("active_status")
     private String activeStatus;
+
+    @JsonProperty("anonymous_status")
     private String anonymousStatus;
+
+    @JsonProperty("user_id")
     private Long userId;
+
+    @JsonProperty("replies")
     private List<RecruitmentBoardReplyDTO> replies;
 }

--- a/src/main/java/com/springcooler/sgma/user/query/dto/RecruitmentBoardReplyDTO.java
+++ b/src/main/java/com/springcooler/sgma/user/query/dto/RecruitmentBoardReplyDTO.java
@@ -1,17 +1,33 @@
 package com.springcooler.sgma.user.query.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.time.LocalDateTime;
 
 @Data
 public class RecruitmentBoardReplyDTO {
+    @JsonProperty("reply_id")
     private Long replyId;
+
+    @JsonProperty("content")
     private String content;
+
+    @JsonProperty("created_at")
     private LocalDateTime createdAt;
+
+    @JsonProperty("updated_at")
     private LocalDateTime updatedAt;
+
+    @JsonProperty("active_status")
     private String activeStatus;
+
+    @JsonProperty("anonymous_status")
     private String anonymousStatus;
+
+    @JsonProperty("user_id")
     private Long userId;
+
+    @JsonProperty("comment_id")
     private Long commentId;
 }

--- a/src/main/java/com/springcooler/sgma/user/query/dto/UserDTO.java
+++ b/src/main/java/com/springcooler/sgma/user/query/dto/UserDTO.java
@@ -1,5 +1,9 @@
 package com.springcooler.sgma.user.query.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.springcooler.sgma.user.command.domain.aggregate.AcceptStatus;
+import com.springcooler.sgma.user.command.domain.aggregate.ActiveStatus;
+import com.springcooler.sgma.user.command.domain.aggregate.SignupPath;
 import lombok.Data;
 
 import java.sql.Timestamp;
@@ -7,17 +11,37 @@ import java.time.LocalDateTime;
 
 @Data
 public class UserDTO {
+    @JsonProperty("user_id")
     private Long userId;
-    private String userName;
-    private String password;
-    private String nickname;
-    private String email;
-    private String userStatus;
-    private Timestamp createdAt;
-    private Timestamp withdrawnAt;
-    private String profileImage;
-    private String acceptStatus;
-    private String signupPath;
 
+    @JsonProperty("user_name")
+    private String userName;
+
+    @JsonProperty("password")
+    private String password;
+
+    @JsonProperty("nickname")
+    private String nickname;
+
+    @JsonProperty("email")
+    private String email;
+
+    @JsonProperty("user_status")
+    private ActiveStatus userStatus;  // Enum 타입으로 정의
+
+    @JsonProperty("created_at")
+    private LocalDateTime createdAt;
+
+    @JsonProperty("withdrawn_at")
+    private LocalDateTime withdrawnAt;
+
+    @JsonProperty("profile_image")
+    private String profileImage;
+
+    @JsonProperty("accept_status")
+    private AcceptStatus acceptStatus;  // Enum 타입으로 정의
+
+    @JsonProperty("signup_path")
+    private SignupPath signupPath;  // Enum 타입으로 정의
     // 기본 생성자, 모든 필드를 포함한 생성자, 필요한 경우 빌더 패턴 등을 추가할 수 있습니다.
 }

--- a/src/main/java/com/springcooler/sgma/user/query/service/RecruitmentCommentServiceImpl.java
+++ b/src/main/java/com/springcooler/sgma/user/query/service/RecruitmentCommentServiceImpl.java
@@ -9,7 +9,9 @@ import com.springcooler.sgma.user.query.repository.RecruitmentCommentMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 public class RecruitmentCommentServiceImpl implements RecruitmentCommentService {
@@ -31,11 +33,12 @@ public class RecruitmentCommentServiceImpl implements RecruitmentCommentService 
             throw new CommonException(ErrorCode.NOT_FOUND_RECRUITMENT_BOARD_COMMENT);
         }
 
-        // 통합 DTO 생성 및 반환
+        // 기존 Map 사용 대신, List로 그대로 반환
         UserCommentsAndRepliesDTO result = new UserCommentsAndRepliesDTO();
-        result.setComments(comments != null ? comments : List.of());
-        result.setReplies(replies != null ? replies : List.of());
+        result.setComments(comments);  // List를 그대로 설정
+        result.setReplies(replies);    // List를 그대로 설정
 
         return result;
     }
+
 }

--- a/src/main/java/com/springcooler/sgma/user/query/service/UserService.java
+++ b/src/main/java/com/springcooler/sgma/user/query/service/UserService.java
@@ -4,7 +4,7 @@ import com.springcooler.sgma.user.query.dto.UserDTO;
 import com.springcooler.sgma.user.query.repository.UserMapper;
 
 public interface UserService {
-    UserDTO getUserByuUserId(Long userId);         // 사용자 ID로 조회
+    UserDTO getUserByUserId(Long userId);         // 사용자 ID로 조회
     UserDTO getUserByNickname(String nickname);    // 사용자 닉네임으로 조회
 
 }

--- a/src/main/java/com/springcooler/sgma/user/query/service/UserServiceImpl.java
+++ b/src/main/java/com/springcooler/sgma/user/query/service/UserServiceImpl.java
@@ -16,7 +16,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public UserDTO getUserByuUserId(Long userId) {
+    public UserDTO getUserByUserId(Long userId) {
         UserDTO user = userMapper.findByUserId(userId);
         if (user == null) {
             throw new CommonException(ErrorCode.NOT_FOUND_USER);

--- a/src/test/java/com/springcooler/sgma/user/query/service/UserServiceImplTests.java
+++ b/src/test/java/com/springcooler/sgma/user/query/service/UserServiceImplTests.java
@@ -10,6 +10,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 @Slf4j
 @SpringBootTest
@@ -28,7 +30,7 @@ class UserServiceImplTests {
         log.info("회원 ID로 사용자 조회 테스트 시작");
 
         // 이미 데이터베이스에 존재하는 user_id 1에 대한 테스트
-        UserDTO foundUser = userService.getUserByuUserId(1L);
+        UserDTO foundUser = userService.getUserByUserId(1L);
 
         log.info("조회된 사용자 정보: {}", foundUser);
 
@@ -36,6 +38,10 @@ class UserServiceImplTests {
         assertThat(foundUser.getUserId()).isEqualTo(1L);
         assertThat(foundUser.getUserName()).isEqualTo("조찬국");
         assertThat(foundUser.getEmail()).isEqualTo("alice@example.com");
+
+        // expected LocalDateTime
+        LocalDateTime expectedDateTime = LocalDateTime.of(2023, 8, 1, 10, 30);
+        assertThat(foundUser.getCreatedAt()).isEqualTo(expectedDateTime);
 
         log.info("회원 ID로 사용자 조회 테스트 성공");
     }
@@ -45,13 +51,13 @@ class UserServiceImplTests {
     void getUserByNickname_success() {
         log.info("회원 닉네임으로 사용자 조회 테스트 시작");
 
-        // 이미 데이터베이스에 존재하는 nickname "alice01"에 대한 테스트
-        UserDTO foundUser = userService.getUserByNickname("alice01");
+        // 이미 데이터베이스에 존재하는 nickname "조짠국"에 대한 테스트
+        UserDTO foundUser = userService.getUserByNickname("조짠국");
 
         log.info("조회된 사용자 정보: {}", foundUser);
 
         assertThat(foundUser).isNotNull();
-        assertThat(foundUser.getNickname()).isEqualTo("alice01");
+        assertThat(foundUser.getNickname()).isEqualTo("조짠국");
         assertThat(foundUser.getEmail()).isEqualTo("alice@example.com");
 
         log.info("회원 닉네임으로 사용자 조회 테스트 성공");


### PR DESCRIPTION
---
name: 기능 개발 이슈
about: 구현된 기능을 상세히 설명하는 템플릿
title: 'user 도메인 json형식 수정 및 시간 타입 변경'
labels: enhancement
assignees: '조창욱'
---

## 코드 변경 사유
- [ ] 신규 기능 추가
- [x] 기존 기능 수정
- [ ] 버그 수정



## 테스트 계획 및 진행 상황
- [x] 사용자 비활성화 시간 정확성 검증 테스트

소스코드
```Java

package com.springcooler.sgma.user.command.domain.aggregate;

import jakarta.persistence.*;
import lombok.Data;

import java.time.LocalDateTime;

@Entity
@Table(name = "USER")
@Data
public class UserEntity {

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    @Column(name = "user_id")
    private Long userId;

    @Column(name = "user_name", nullable = false, length = 255)
    private String userName;

    @Column(name = "password", length = 255)
    private String password;

    @Column(name = "nickname", nullable = false, length = 255)
    private String nickname;

    @Column(name = "email", nullable = false, length = 255)
    private String email;

    @Enumerated(EnumType.STRING)
    @Column(name = "user_status", nullable = false, length = 255)
    private ActiveStatus userStatus =  ActiveStatus.ACTIVE; //필기. Enum타입으로 정의

    @Column(name = "created_at")
    private LocalDateTime createdAt;

    @Column(name = "withdrawn_at")
    private LocalDateTime withdrawnAt;

    @Column(name = "profile_image", columnDefinition = "TEXT")
    private String profileImage;

    @Enumerated(EnumType.STRING)
    @Column(name = "accept_status", nullable = false, length = 255)
    private AcceptStatus acceptStatus = AcceptStatus.N;  //필기. Enum타입으로 정의

    @Enumerated(EnumType.STRING)
    @Column(name = "signup_path", length = 255)
    private SignupPath signupPath; //필기. Enum타입으로 정의

    // 사용자 정보 비활성화로 설정
    public void deactivateUser() {
        this.userStatus = ActiveStatus.INACTIVE;
        this.withdrawnAt = LocalDateTime.now().withNano(0); // 필기. 초 단위까지만 설정
    }

    // 사용자 정보 활성화로 설정
    public void activateUser() {
        this.userStatus = ActiveStatus.ACTIVE;
        this.withdrawnAt = null; // 재활성화 시 탈퇴 시간을 초기화
    }

    // 사용자 정보 변경(닉네임, 사진)
    public void updateProfile(String nickname, String profileImage) {
        if (nickname != null && !nickname.isEmpty()) {
            this.nickname = nickname;
        }
        if (profileImage != null && !profileImage.isEmpty()) {
            this.profileImage = profileImage;
        }
    }
}

```

테스트코드
```Java
  @Test
    @DisplayName("사용자 비활성화 시간 정확성 검증 테스트")
    void deactivateUser_TimeExactMatchVerification() {
        // Given
        Long userId = 1L;  // 실제 DB에 존재하는 사용자 ID로 변경 필요
        UserEntity userEntity = userRepository.findById(userId)
                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_USER));

        // When
        UserEntity result = userServiceImpl.deactivateUser(userId);

        // Then
        assertNotNull(result);
        assertEquals(ActiveStatus.INACTIVE, result.getUserStatus());

        // 현재 시간을 기준으로 withdrawnAt이 정확히 같은지 확인 (초 단위까지)
        LocalDateTime now = LocalDateTime.now().withNano(0);
        LocalDateTime withdrawnAt = result.getWithdrawnAt();
        assertNotNull(withdrawnAt);
        assertTrue(ChronoUnit.SECONDS.between(withdrawnAt, now) < 1,
                "withdrawnAt 시간이 현재 시간과 1초 이내여야 합니다.");
    }
```

테스트결과

![image](https://github.com/user-attachments/assets/2a77ef3f-9806-4070-a535-f225c5610bfe)



## 기타 참고 사항
- 시간필드는 LocalDateTime으로 정의 했고, 현재 시각을 LocalDateTime.now().withNano(0);으로 하여 yyyy-MM-dd'T'HH:mm:ss로 통일하였습니다.
- Enum 타입 필드들은 String에서 Enum 타입으로 설정했습니다. 이는 유지보수성을 높이기 위해 리팩토링을 진행하였습니다.

close #97 