### PR TITLE
JsonProperty -> JsonNaming으로 수정 #165

### DIFF
--- a/MSA/Recruitment/src/main/java/com/springcooler/sgma/recruitmentboard/command/application/dto/RecruitmentBoardCommandDTO.java
+++ b/MSA/Recruitment/src/main/java/com/springcooler/sgma/recruitmentboard/command/application/dto/RecruitmentBoardCommandDTO.java
@@ -1,5 +1,7 @@
 package com.springcooler.sgma.recruitmentboard.command.application.dto;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -11,6 +13,7 @@ import java.sql.Timestamp;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class RecruitmentBoardCommandDTO {
     private Long recruitmentBoardId;
     private String title;

--- a/MSA/Recruitment/src/main/java/com/springcooler/sgma/recruitmentboard/query/dto/RecruitmentBoardDTO.java
+++ b/MSA/Recruitment/src/main/java/com/springcooler/sgma/recruitmentboard/query/dto/RecruitmentBoardDTO.java
@@ -1,44 +1,36 @@
 package com.springcooler.sgma.recruitmentboard.query.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.sql.Timestamp;
 
 @Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class RecruitmentBoardDTO {
 
-    @JsonProperty("recruitment_board_id")
     private Long recruitmentBoardId;
 
-    @JsonProperty("title")
     private String title;
 
-    @JsonProperty("content")
     private String content;
 
-    @JsonProperty("created_at")
     private Timestamp createdAt;
 
-    @JsonProperty("updated_at")
     private Timestamp updatedAt;
 
-    @JsonProperty("recruitment_start_time")
     private Timestamp recruitmentStartTime;
 
-    @JsonProperty("recruitment_end_time")
     private Timestamp recruitmentEndTime;
 
-    @JsonProperty("active_status")
     private String activeStatus;
 
-    @JsonProperty("likes")
     private Integer likes;
 
-    @JsonProperty("group_id")
     private Long groupId;
 
-    @JsonProperty("category_id")
     private Integer studyGroupCategoryId;
 
 }

--- a/MSA/Recruitment/src/main/java/com/springcooler/sgma/recruitmentboardcomment/command/application/dto/RecruitmentBoardCommentCommandDTO.java
+++ b/MSA/Recruitment/src/main/java/com/springcooler/sgma/recruitmentboardcomment/command/application/dto/RecruitmentBoardCommentCommandDTO.java
@@ -1,5 +1,7 @@
 package com.springcooler.sgma.recruitmentboardcomment.command.application.dto;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
 
 import java.sql.Timestamp;
@@ -8,6 +10,7 @@ import java.sql.Timestamp;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class RecruitmentBoardCommentCommandDTO {
 
     private Long recruitmentBoardCommentId;

--- a/MSA/Recruitment/src/main/java/com/springcooler/sgma/recruitmentboardcomment/query/dto/RecruitmentBoardCommentDTO.java
+++ b/MSA/Recruitment/src/main/java/com/springcooler/sgma/recruitmentboardcomment/query/dto/RecruitmentBoardCommentDTO.java
@@ -1,35 +1,30 @@
 package com.springcooler.sgma.recruitmentboardcomment.query.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.sql.Timestamp;
 
 @Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class RecruitmentBoardCommentDTO {
 
-    @JsonProperty("recruitment_board_comment_id")
     private Long recruitmentBoardCommentId;
 
-    @JsonProperty("content")
     private String content;
 
-    @JsonProperty("created_at")
     private Timestamp createdAt;
 
-    @JsonProperty("updated_at")
+
     private Timestamp updatedAt;
 
-    @JsonProperty("user_id")
     private long userId;
 
-    @JsonProperty("active_status")
     private String activeStatus;
 
-    @JsonProperty("recruitment_board_id")
     private long recruitmentBoardId;
 
-    @JsonProperty("anonymous_status")
     private String anonymousStatus;
 
 }

--- a/MSA/Recruitment/src/main/java/com/springcooler/sgma/recruitmentboardlike/common/ResponseDTO.java
+++ b/MSA/Recruitment/src/main/java/com/springcooler/sgma/recruitmentboardlike/common/ResponseDTO.java
@@ -1,6 +1,9 @@
 package com.springcooler.sgma.recruitmentboardlike.common;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.springcooler.sgma.recruitmentboardlike.common.exception.CommonException;
 import com.springcooler.sgma.recruitmentboardlike.common.exception.ErrorCode;
 import com.springcooler.sgma.recruitmentboardlike.common.exception.ExceptionDTO;
@@ -17,6 +20,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class ResponseDTO<T> {
 
     @JsonIgnore

--- a/MSA/Recruitment/src/main/java/com/springcooler/sgma/recruitmentboardreply/command/application/dto/RecruitmentBoardReplyDTO.java
+++ b/MSA/Recruitment/src/main/java/com/springcooler/sgma/recruitmentboardreply/command/application/dto/RecruitmentBoardReplyDTO.java
@@ -1,6 +1,8 @@
 package com.springcooler.sgma.recruitmentboardreply.command.application.dto;
 
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,6 +14,7 @@ import java.sql.Timestamp;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class RecruitmentBoardReplyDTO {
 
     private Long recruitmentBoardReplyId;

--- a/MSA/Recruitment/src/main/java/com/springcooler/sgma/recruitmentboardreply/query/dto/RecruitmentBoardReplyDTO.java
+++ b/MSA/Recruitment/src/main/java/com/springcooler/sgma/recruitmentboardreply/query/dto/RecruitmentBoardReplyDTO.java
@@ -2,36 +2,31 @@ package com.springcooler.sgma.recruitmentboardreply.query.dto;
 
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 import java.sql.Timestamp;
 
 
 @Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class RecruitmentBoardReplyDTO {
 
-    @JsonProperty("recruitment_board_reply_id")
     private Long recruitmentBoardReplyId;
 
-    @JsonProperty("content")
     private String content;
 
-    @JsonProperty("created_at")
     private Timestamp createdAt;
 
-    @JsonProperty("updated_at")
     private Timestamp updatedAt;
 
-    @JsonProperty("anonymous_status")
     private String anonymousStatus;
 
-    @JsonProperty("active_status")
     private String activeStatus;
 
-    @JsonProperty("user_id")
     private Long userId;
 
-    @JsonProperty("recruitment_board_comment_id")
     private Long recruitmentBoardCommentId;
 
 }

--- a/MSA/Recruitment/src/main/java/com/springcooler/sgma/studygroupapplicant/command/application/dto/StudyGroupApplicantCommandDTO.java
+++ b/MSA/Recruitment/src/main/java/com/springcooler/sgma/studygroupapplicant/command/application/dto/StudyGroupApplicantCommandDTO.java
@@ -1,8 +1,11 @@
 package com.springcooler.sgma.studygroupapplicant.command.application.dto;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 @Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class StudyGroupApplicantCommandDTO {
     private Long userId;
     private String applicationStatus;

--- a/MSA/Recruitment/src/main/java/com/springcooler/sgma/studygroupapplicant/command/domain/aggregate/vo/RequestStudyGroupMemberVO.java
+++ b/MSA/Recruitment/src/main/java/com/springcooler/sgma/studygroupapplicant/command/domain/aggregate/vo/RequestStudyGroupMemberVO.java
@@ -1,15 +1,15 @@
 package com.springcooler.sgma.studygroupapplicant.command.domain.aggregate.vo;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 @Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class RequestStudyGroupMemberVO {
 
-    @JsonProperty("user_id")
     private Long userId;
 
-    @JsonProperty("group_id")
     private Long groupId;
 
 }

--- a/MSA/Recruitment/src/main/java/com/springcooler/sgma/studygroupapplicant/query/dto/StudyGroupApplicantDTO.java
+++ b/MSA/Recruitment/src/main/java/com/springcooler/sgma/studygroupapplicant/query/dto/StudyGroupApplicantDTO.java
@@ -1,18 +1,18 @@
 package com.springcooler.sgma.studygroupapplicant.query.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 
 @Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class StudyGroupApplicantDTO {
 
-    @JsonProperty("user_id")
     private Long userId;
 
-    @JsonProperty("application_status")
     private String applicationStatus;
 
-    @JsonProperty("recruitment_board_id")
     private Long recruitmentBoardId;
     
 }


### PR DESCRIPTION
---
name: JsonProperty -> JsonNaming
title: Code Refactoring
labels: enhancement
assignees: 'everyone' 

---

## 코드 변경 사유
- [ ] 신규 기능 추가
- [x] 기존 기능 수정
- [ ] 버그 수정


소스코드
```Java
package com.springcooler.sgma.recruitmentboard.query.dto;

import com.fasterxml.jackson.annotation.JsonProperty;
import lombok.Data;

import java.sql.Timestamp;

@Data
public class RecruitmentBoardDTO {

    @JsonProperty("recruitment_board_id")
    private Long recruitmentBoardId;

    @JsonProperty("title")
    private String title;

    @JsonProperty("content")
    private String content;

    @JsonProperty("created_at")
    private Timestamp createdAt;

    @JsonProperty("updated_at")
    private Timestamp updatedAt;

    @JsonProperty("recruitment_start_time")
    private Timestamp recruitmentStartTime;

    @JsonProperty("recruitment_end_time")
    private Timestamp recruitmentEndTime;

    @JsonProperty("active_status")
    private String activeStatus;

    @JsonProperty("likes")
    private Integer likes;

    @JsonProperty("group_id")
    private Long groupId;

    @JsonProperty("category_id")
    private Integer studyGroupCategoryId;
}

@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
public class RecruitmentBoardDTO {

    private Long recruitmentBoardId;

    private String title;

    private String content;

    private Timestamp createdAt;

    private Timestamp updatedAt;

    private Timestamp recruitmentStartTime;

    private Timestamp recruitmentEndTime;

    private String activeStatus;

    private Integer likes;

    private Long groupId;

    private Integer studyGroupCategoryId;

}
```
![image](https://github.com/user-attachments/assets/c4d3acd6-21d3-4fce-85a9-2f9816841dcf)
deprecated 이슈로 PropertyNamingStrategies.SnakeCaseStrategy.class를 사용함
