### PR TITLE
Feat: 스터디그룹 자유게시판 내용으로 조회 기능 구현

### DIFF
--- a/MSA/Group/src/main/java/com/springcooler/sgma/studygroupboard/query/controller/StudyGroupBoardController.java
+++ b/MSA/Group/src/main/java/com/springcooler/sgma/studygroupboard/query/controller/StudyGroupBoardController.java
@@ -43,6 +43,13 @@ public class StudyGroupBoardController {
         return ResponseDTO.ok(boards);
     }
 
+    // 게시글 내용으로 조회
+    @GetMapping("/content/{content}")
+    public ResponseDTO<?> findStudyGroupBoardsByContent(@PathVariable("content") String content) {
+        List<StudyGroupBoardDTO> boards = studyGroupBoardService.findStudyGroupBoardsByContent(content);
+        return ResponseDTO.ok(boards);
+    }
+
     // 게시글 단건 조회
     @GetMapping("/{boardId}")
     public ResponseDTO<?> findStudyGroupBoardsByBoardId(@PathVariable("boardId") Long boardId) {

--- a/MSA/Group/src/main/java/com/springcooler/sgma/studygroupboard/query/repository/StudyGroupBoardMapper.java
+++ b/MSA/Group/src/main/java/com/springcooler/sgma/studygroupboard/query/repository/StudyGroupBoardMapper.java
@@ -17,6 +17,9 @@ public interface StudyGroupBoardMapper {
     // 게시글 제목으로 조회
     List<StudyGroupBoardDTO> findStudyGroupBoardsByTitle(String title);
 
+    // 게시글 내용으로 조회
+    List<StudyGroupBoardDTO> findStudyGroupBoardsByContent(String content);
+
     // 게시글 단건 조회
     StudyGroupBoardDTO findStudyGroupBoardByBoardId(Long boardId);
 

--- a/MSA/Group/src/main/java/com/springcooler/sgma/studygroupboard/query/service/StudyGroupBoardService.java
+++ b/MSA/Group/src/main/java/com/springcooler/sgma/studygroupboard/query/service/StudyGroupBoardService.java
@@ -15,6 +15,9 @@ public interface StudyGroupBoardService {
     // 게시글 제목으로 조회
     List<StudyGroupBoardDTO> findStudyGroupBoardsByTitle(String title);
 
+    // 게시글 내용으로 조회
+    List<StudyGroupBoardDTO> findStudyGroupBoardsByContent(String content);
+
     // 게시글 단건 조회
     StudyGroupBoardDTO findStudyGroupBoardByBoardId(Long boardId);
 

--- a/MSA/Group/src/main/java/com/springcooler/sgma/studygroupboard/query/service/StudyGroupBoardServiceImpl.java
+++ b/MSA/Group/src/main/java/com/springcooler/sgma/studygroupboard/query/service/StudyGroupBoardServiceImpl.java
@@ -49,6 +49,16 @@ public class StudyGroupBoardServiceImpl implements StudyGroupBoardService {
         return boards;
     }
 
+    // 게시글 내용으로 조회
+    @Override
+    public List<StudyGroupBoardDTO> findStudyGroupBoardsByContent(String content) {
+        List<StudyGroupBoardDTO> boards = studyGroupBoardMapper.findStudyGroupBoardsByContent(content);
+        if(boards == null || boards.isEmpty()) {
+            throw new CommonException(ErrorCode.NOT_FOUND_STUDY_GROUP_BOARD);
+        }
+        return boards;
+    }
+
     // 게시글 단건 조회
     @Override
     public StudyGroupBoardDTO findStudyGroupBoardByBoardId(Long boardId) {

--- a/MSA/Group/src/main/resources/com/springcooler/sgma/studygroup/query/repository/StudyGroupMapper.xml
+++ b/MSA/Group/src/main/resources/com/springcooler/sgma/studygroup/query/repository/StudyGroupMapper.xml
@@ -89,6 +89,6 @@
              , A.USER_ID
              , A.STUDY_GROUP_CATEGORY_ID
           FROM STUDY_GROUP A
-         WHERE A.GROUP_NAME = #{ groupName } AND A.ACTIVE_STATUS = 'ACTIVE'
+         WHERE A.ACTIVE_STATUS = 'ACTIVE' AND A.GROUP_NAME LIKE CONCAT('%', #{ groupName }, '%')
     </select>
 </mapper>

--- a/MSA/Group/src/main/resources/com/springcooler/sgma/studygroupboard/query/repository/StudyGroupBoardMapper.xml
+++ b/MSA/Group/src/main/resources/com/springcooler/sgma/studygroupboard/query/repository/StudyGroupBoardMapper.xml
@@ -57,7 +57,22 @@
              , A.MEMBER_ID
              , A.GROUP_ID
           FROM STUDY_GROUP_BOARD A
-         WHERE A.ACTIVE_STATUS = 'ACTIVE' AND A.TITLE LIKE CONCAT('%', #{title}, '%')
+         WHERE A.ACTIVE_STATUS = 'ACTIVE' AND A.TITLE LIKE CONCAT('%', #{ title }, '%')
+    </select>
+
+    <select id="findStudyGroupBoardsByContent" resultMap="studyGroupBoardResultMap" parameterType="string">
+        SELECT
+        A.STUDY_GROUP_BOARD_ID
+        , A.TITLE
+        , A.CONTENT
+        , A.CREATED_AT
+        , A.UPDATED_AT
+        , A.ACTIVE_STATUS
+        , A.LIKES
+        , A.MEMBER_ID
+        , A.GROUP_ID
+        FROM STUDY_GROUP_BOARD A
+        WHERE A.ACTIVE_STATUS = 'ACTIVE' AND A.CONTENT LIKE CONCAT('%', #{ content }, '%')
     </select>
 
     <select id="findStudyGroupBoardByBoardId" resultMap="studyGroupBoardResultMap" parameterType="Long">

--- a/MSA/Group/src/test/java/com/springcooler/sgma/studygroupboard/query/service/StudyGroupBoardServiceTests.java
+++ b/MSA/Group/src/test/java/com/springcooler/sgma/studygroupboard/query/service/StudyGroupBoardServiceTests.java
@@ -44,7 +44,7 @@ class StudyGroupBoardServiceTests {
         );
     }
 
-    @DisplayName("게시글 그룹별 조회 테스트")
+    @DisplayName("게시글 제목으로 조회 테스트")
     @ParameterizedTest
     @ValueSource(strings = "험")
     void testFindStudyGroupBoardsByTitle(String title) {
@@ -57,7 +57,20 @@ class StudyGroupBoardServiceTests {
         );
     }
 
-    @DisplayName("게시글 그룹별 조회 테스트")
+    @DisplayName("게시글 내용으로 조회 테스트")
+    @ParameterizedTest
+    @ValueSource(strings = "다음")
+    void testFindStudyGroupBoardsByContent(String content) {
+        Assertions.assertDoesNotThrow(
+                () -> {
+                    List<StudyGroupBoardDTO> boards =
+                            studyGroupBoardService.findStudyGroupBoardsByContent(content);
+                    boards.forEach(x -> log.info(x.toString()));
+                }
+        );
+    }
+
+    @DisplayName("게시글 단건 조회 테스트")
     @ParameterizedTest
     @ValueSource(longs = 3L)
     void testFindStudyGroupBoardByBoardId(Long boardId) {


### PR DESCRIPTION
---
name: 기능 구현
about: 스터디그룹 자유게시판 내용으로 조회 기능 구현
title: 기능 구현
labels: enhancement
assignees: '' (PR 리뷰어)

---

## 코드 변경 사유
- [x] 신규 기능 추가
- [ ] 기존 기능 수정
- [ ] 버그 수정

## 관련 이슈 (버그 수정인 경우)
- 
- 

## 테스트 계획 및 진행 상황
- [x] 스터디그룹 자유게시판 내용으로 조회 기능 구현

소스코드
```Java
    // 게시글 내용으로 조회
    @Override
    public List<StudyGroupBoardDTO> findStudyGroupBoardsByContent(String content) {
        List<StudyGroupBoardDTO> boards = studyGroupBoardMapper.findStudyGroupBoardsByContent(content);
        if(boards == null || boards.isEmpty()) {
            throw new CommonException(ErrorCode.NOT_FOUND_STUDY_GROUP_BOARD);
        }
        return boards;
    }
```

테스트코드
```Java
    @DisplayName("게시글 내용으로 조회 테스트")
    @ParameterizedTest
    @ValueSource(strings = "다음")
    void testFindStudyGroupBoardsByContent(String content) {
        Assertions.assertDoesNotThrow(
                () -> {
                    List<StudyGroupBoardDTO> boards =
                            studyGroupBoardService.findStudyGroupBoardsByContent(content);
                    boards.forEach(x -> log.info(x.toString()));
                }
        );
    }
```

테스트결과

![image](https://github.com/user-attachments/assets/5f797e80-bf74-4314-a8f8-1720bbfb3880)

## 기타 참고 사항
- close #202 
