### PR TITLE
Feat: 내가 가입한 스터디그룹 전체 조회 기능 추가

### DIFF
--- a/MSA/Group/src/main/java/com/springcooler/sgma/studygroup/query/controller/StudyGroupController.java
+++ b/MSA/Group/src/main/java/com/springcooler/sgma/studygroup/query/controller/StudyGroupController.java
@@ -1,6 +1,7 @@
 package com.springcooler.sgma.studygroup.query.controller;
 
 import com.springcooler.sgma.studygroup.common.ResponseDTO;
+import com.springcooler.sgma.studygroup.query.dto.MyStudyGroupDTO;
 import com.springcooler.sgma.studygroup.query.dto.StudyGroupDTO;
 import com.springcooler.sgma.studygroup.query.service.StudyGroupService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,6 +60,13 @@ public class StudyGroupController {
     public ResponseDTO<?> findStudyGroupByGroupName(@PathVariable("groupName") String groupName) {
         StudyGroupDTO studyGroup = studyGroupService.findStudyGroupByGroupName(groupName);
         return ResponseDTO.ok(studyGroup);
+    }
+
+    // 내가 가입한 스터디 그룹 전체 조회
+    @GetMapping("/user/{userId}")
+    public ResponseDTO<?> findStudyGroupsByUserId(@PathVariable("userId") Long userId) {
+        List<MyStudyGroupDTO> studyGroups = studyGroupService.findStudyGroupsByUserId(userId);
+        return ResponseDTO.ok(studyGroups);
     }
 
 }

--- a/MSA/Group/src/main/java/com/springcooler/sgma/studygroup/query/dto/MyStudyGroupDTO.java
+++ b/MSA/Group/src/main/java/com/springcooler/sgma/studygroup/query/dto/MyStudyGroupDTO.java
@@ -1,0 +1,40 @@
+package com.springcooler.sgma.studygroup.query.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.springcooler.sgma.studygroupmember.command.domain.aggregate.GroupRole;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class MyStudyGroupDTO {
+
+    @JsonProperty("group_id")
+    private Long groupId;
+
+    @JsonProperty("group_name")
+    private String groupName;
+
+    @JsonProperty("category_id")
+    private Integer studyGroupCategoryId;
+
+    @JsonProperty("category_name")
+    private String categoryName;
+
+    @JsonProperty("member_id")
+    private Long memberId;
+
+    @JsonProperty("member_enrolled_at")
+    private LocalDateTime memberEnrolledAt;
+
+    @Enumerated(EnumType.STRING)
+    @JsonProperty("group_role")
+    private GroupRole groupRole;
+
+}

--- a/MSA/Group/src/main/java/com/springcooler/sgma/studygroup/query/repository/StudyGroupMapper.java
+++ b/MSA/Group/src/main/java/com/springcooler/sgma/studygroup/query/repository/StudyGroupMapper.java
@@ -1,5 +1,6 @@
 package com.springcooler.sgma.studygroup.query.repository;
 
+import com.springcooler.sgma.studygroup.query.dto.MyStudyGroupDTO;
 import com.springcooler.sgma.studygroup.query.dto.StudyGroupDTO;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -25,5 +26,8 @@ public interface StudyGroupMapper {
 
     // 스터디그룹 단건 조회(그룹 이름)
     StudyGroupDTO findStudyGroupByGroupName(String groupName);
+
+    // 내가 가입한 스터디 그룹 전체 조회
+    List<MyStudyGroupDTO> findStudyGroupsByUserId(Long userId);
 
 }

--- a/MSA/Group/src/main/java/com/springcooler/sgma/studygroup/query/service/StudyGroupService.java
+++ b/MSA/Group/src/main/java/com/springcooler/sgma/studygroup/query/service/StudyGroupService.java
@@ -1,5 +1,6 @@
 package com.springcooler.sgma.studygroup.query.service;
 
+import com.springcooler.sgma.studygroup.query.dto.MyStudyGroupDTO;
 import com.springcooler.sgma.studygroup.query.dto.StudyGroupDTO;
 
 import java.util.List;
@@ -23,5 +24,8 @@ public interface StudyGroupService {
 
     // 스터디 그룹 단건 조회(그룹 이름)
     StudyGroupDTO findStudyGroupByGroupName(String groupName);
+
+    // 내가 가입한 스터디 그룹 전체 조회
+    List<MyStudyGroupDTO> findStudyGroupsByUserId(Long userId);
 
 }

--- a/MSA/Group/src/main/java/com/springcooler/sgma/studygroup/query/service/StudyGroupServiceImpl.java
+++ b/MSA/Group/src/main/java/com/springcooler/sgma/studygroup/query/service/StudyGroupServiceImpl.java
@@ -1,5 +1,6 @@
 package com.springcooler.sgma.studygroup.query.service;
 
+import com.springcooler.sgma.studygroup.query.dto.MyStudyGroupDTO;
 import com.springcooler.sgma.studygroup.query.dto.StudyGroupDTO;
 import com.springcooler.sgma.studygroup.query.repository.StudyGroupMapper;
 import com.springcooler.sgma.studygroup.common.exception.CommonException;
@@ -77,6 +78,16 @@ public class StudyGroupServiceImpl implements StudyGroupService {
             throw new CommonException(ErrorCode.NOT_FOUND_STUDY_GROUP);
         }
         return studyGroup;
+    }
+
+    // 내가 가입한 스터디 그룹 전체 조회
+    @Override
+    public List<MyStudyGroupDTO> findStudyGroupsByUserId(Long userId) {
+        List<MyStudyGroupDTO> studyGroups = studyGroupMapper.findStudyGroupsByUserId(userId);
+        if(studyGroups == null || studyGroups.isEmpty()) {
+            throw new CommonException(ErrorCode.NOT_FOUND_STUDY_GROUP);
+        }
+        return studyGroups;
     }
 
 }

--- a/MSA/Group/src/main/resources/com/springcooler/sgma/studygroup/query/repository/StudyGroupMapper.xml
+++ b/MSA/Group/src/main/resources/com/springcooler/sgma/studygroup/query/repository/StudyGroupMapper.xml
@@ -12,6 +12,16 @@
         <result property="studyGroupCategoryId" column="STUDY_GROUP_CATEGORY_ID"/>
     </resultMap>
 
+    <resultMap id="myStudyGroupResultMap" type="com.springcooler.sgma.studygroup.query.dto.MyStudyGroupDTO">
+        <id property="groupId" column="GROUP_ID"/>
+        <result property="groupName" column="GROUP_NAME"/>
+        <result property="studyGroupCategoryId" column="STUDY_GROUP_CATEGORY_ID"/>
+        <result property="categoryName" column="STUDY_GROUP_CATEGORY_NAME"/>
+        <result property="memberId" column="MEMBER_ID"/>
+        <result property="memberEnrolledAt" column="MEMBER_ENROLLED_AT"/>
+        <result property="groupRole" column="GROUP_ROLE"/>
+    </resultMap>
+
     <select id="findAllStudyGroups" resultMap="studyGroupResultMap">
         SELECT
                A.GROUP_ID
@@ -49,9 +59,9 @@
           FROM STUDY_GROUP A
           JOIN STUDY_GROUP_MEMBER B
             ON A.GROUP_ID = B.GROUP_ID
-          JOIN USER C
-            ON B.USER_ID = C.USER_ID
-         WHERE C.USER_ID = #{ participantId } AND A.ACTIVE_STATUS = 'ACTIVE'
+         WHERE B.USER_ID = #{ participantId }
+           AND A.ACTIVE_STATUS = 'ACTIVE'
+           AND B.MEMBER_STATUS = 'ACTIVE'
          ORDER BY A.GROUP_ID
     </select>
 
@@ -90,5 +100,25 @@
              , A.STUDY_GROUP_CATEGORY_ID
           FROM STUDY_GROUP A
          WHERE A.ACTIVE_STATUS = 'ACTIVE' AND A.GROUP_NAME LIKE CONCAT('%', #{ groupName }, '%')
+    </select>
+
+    <select id="findStudyGroupsByUserId" resultMap="myStudyGroupResultMap" parameterType="Long">
+        SELECT
+               A.GROUP_ID
+             , A.GROUP_NAME
+             , A.STUDY_GROUP_CATEGORY_ID
+             , B.STUDY_GROUP_CATEGORY_NAME
+             , C.MEMBER_ID
+             , C.MEMBER_ENROLLED_AT
+             , C.GROUP_ROLE
+          FROM STUDY_GROUP A
+          JOIN STUDY_GROUP_CATEGORY B
+            ON A.STUDY_GROUP_CATEGORY_ID = B.STUDY_GROUP_CATEGORY_ID
+          JOIN STUDY_GROUP_MEMBER C
+            ON A.GROUP_ID = C.GROUP_ID
+         WHERE C.USER_ID = #{ userId }
+           AND A.ACTIVE_STATUS = 'ACTIVE'
+           AND C.MEMBER_STATUS = 'ACTIVE'
+         ORDER BY A.GROUP_ID
     </select>
 </mapper>

--- a/MSA/Group/src/test/java/com/springcooler/sgma/studygroup/query/service/StudyGroupServiceTests.java
+++ b/MSA/Group/src/test/java/com/springcooler/sgma/studygroup/query/service/StudyGroupServiceTests.java
@@ -1,5 +1,6 @@
 package com.springcooler.sgma.studygroup.query.service;
 
+import com.springcooler.sgma.studygroup.query.dto.MyStudyGroupDTO;
 import com.springcooler.sgma.studygroup.query.dto.StudyGroupDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
@@ -86,6 +87,18 @@ class StudyGroupServiceTests {
                 () -> {
                     StudyGroupDTO studyGroup = studyGroupService.findStudyGroupByGroupName(groupName);
                     log.info(studyGroup.toString());
+                }
+        );
+    }
+
+    @DisplayName("내가 가입한 스터디그룹 조회 테스트")
+    @ParameterizedTest
+    @ValueSource(longs = 1L)
+    void testFindStudyGroupsByUserId(Long userId) {
+        Assertions.assertDoesNotThrow(
+                () -> {
+                    List<MyStudyGroupDTO> studyGroups = studyGroupService.findStudyGroupsByUserId(userId);
+                    studyGroups.forEach(x -> log.info(x.toString()));
                 }
         );
     }


### PR DESCRIPTION
---
name: 기능 구현
about: 내가 가입한 스터디그룹 전체 조회 기능 추가
title: 내가 가입한 스터디그룹 전체 조회 기능 추가
labels: enhancement
assignees: '' (PR 리뷰어)

---

## 코드 변경 사유
- [x] 신규 기능 추가
- [ ] 기존 기능 수정
- [ ] 버그 수정

## 관련 이슈 (버그 수정인 경우)
- 
- 

## 테스트 계획 및 진행 상황
- [x] 카테고리명, 그룹장 여부, 그룹 가입시각이 잘 나오는가?

소스코드
```Xml
    <select id="findStudyGroupsByUserId" resultMap="myStudyGroupResultMap" parameterType="Long">
        SELECT
               A.GROUP_ID
             , A.GROUP_NAME
             , A.STUDY_GROUP_CATEGORY_ID
             , B.STUDY_GROUP_CATEGORY_NAME
             , C.MEMBER_ID
             , C.MEMBER_ENROLLED_AT
             , C.GROUP_ROLE
          FROM STUDY_GROUP A
          JOIN STUDY_GROUP_CATEGORY B
            ON A.STUDY_GROUP_CATEGORY_ID = B.STUDY_GROUP_CATEGORY_ID
          JOIN STUDY_GROUP_MEMBER C
            ON A.GROUP_ID = C.GROUP_ID
         WHERE C.USER_ID = #{ userId }
           AND A.ACTIVE_STATUS = 'ACTIVE'
           AND C.MEMBER_STATUS = 'ACTIVE'
         ORDER BY A.GROUP_ID
    </select>
```

테스트코드
```Java
    @DisplayName("내가 가입한 스터디그룹 조회 테스트")
    @ParameterizedTest
    @ValueSource(longs = 1L)
    void testFindStudyGroupsByUserId(Long userId) {
        Assertions.assertDoesNotThrow(
                () -> {
                    List<MyStudyGroupDTO> studyGroups = studyGroupService.findStudyGroupsByUserId(userId);
                    studyGroups.forEach(x -> log.info(x.toString()));
                }
        );
    }
```

테스트결과

![image](https://github.com/user-attachments/assets/0d224004-0221-4593-bd8e-d209786bb550)

---

## 기타 참고 사항
- close #232 
