### PR TITLE
Refactor: Get 요청시 RequestParam으로 호출

### DIFF
--- a/MSA/User/src/main/java/com/springcooler/sgma/user/query/controller/UserController.java
+++ b/MSA/User/src/main/java/com/springcooler/sgma/user/query/controller/UserController.java
@@ -47,16 +47,24 @@ public class UserController {
     }
 
     // 사용자 이메일로 사용자 조회
+//    @GetMapping("/identifier")
+//    public ResponseDTO<UserDTO> getUserByUserIdentifier(@RequestBody RequestUserIdentifierDTO requestUserIdentifierDTO) {
+//        UserDTO userDTO = userService.getUserByUserIdentifier(requestUserIdentifierDTO.getUserIdentifier());
+//        return ResponseDTO.ok(userDTO);
+//    }
+
     @GetMapping("/identifier")
-    public ResponseDTO<UserDTO> getUserByUserIdentifier(@RequestBody RequestUserIdentifierDTO requestUserIdentifierDTO) {
-        UserDTO userDTO = userService.getUserByUserIdentifier(requestUserIdentifierDTO.getUserIdentifier());
+    public ResponseDTO<UserDTO> getUserByUserIdentifier(@RequestParam("user_identifier") String userIdentifier)  {
+        UserDTO userDTO = userService.getUserByUserIdentifier(userIdentifier);
         return ResponseDTO.ok(userDTO);
     }
 
     @GetMapping("/auth-id")
-    public ResponseDTO<UserDTO> getUserByUserNameAndSignupPathAndEmail(@RequestBody RequestUserAuthIdDTO request) {
+    public ResponseDTO<UserDTO> getUserByUserNameAndSignupPathAndEmail(
+            @RequestParam String nickname,
+            @RequestParam String email) {
         //필기. 닉네임, 가입 구분, 이메일이 일치하는 사용자가 있는지 확인
-        UserDTO userDTO = userService.findUserByUserNicknameAndSignupPathAndEmail(request.getNickname(), SignupPath.NORMAL, request.getEmail());
+        UserDTO userDTO = userService.findUserByUserNicknameAndSignupPathAndEmail(nickname, SignupPath.NORMAL, email);
         return ResponseDTO.ok(userDTO);
     }
 


### PR DESCRIPTION
---
name: 기능 개발 이슈
about: 구현된 기능을 상세히 설명하는 템플릿
title: 'Get 요청시 RequestParam으로 호출'
labels: enhancement
assignees: '조창욱'

---

## 코드 변경 사유
- [ ] 신규 기능 추가
- [ ] 기존 기능 수정
- [ ] 버그 수정

## 관련 이슈 (버그 수정인 경우)
-  GET 요청시 Request Body 불가

소스코드
```Java

    @GetMapping("/auth-id")
    public ResponseDTO<UserDTO> getUserByUserNameAndSignupPathAndEmail(
            @RequestParam String nickname,
            @RequestParam String email) {
        //필기. 닉네임, 가입 구분, 이메일이 일치하는 사용자가 있는지 확인
        UserDTO userDTO = userService.findUserByUserNicknameAndSignupPathAndEmail(nickname, SignupPath.NORMAL, email);
        return ResponseDTO.ok(userDTO);
    }
```


## 기타 참고 사항
- 표준 http는 Get요청에 Json Body를 담을 수 없다. 따라서 RequestParam으로 형식 변경
